### PR TITLE
Fill large area crash

### DIFF
--- a/RealmFactory/DataModel/Level.cs
+++ b/RealmFactory/DataModel/Level.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Starbound.RealmFactory.DataModel
 {

--- a/RealmFactory/Form1.cs
+++ b/RealmFactory/Form1.cs
@@ -12,22 +12,22 @@ namespace RealmEngine
 {
     public partial class Form1 : Form
     {
-        private FileReaderManager<Project> fileReaderManager;
-        private FileWriterManager<Project> fileWriterManager;
+        private FileReaderManager<Project> _fileReaderManager;
+        private FileWriterManager<Project> _fileWriterManager;
 
-        private UndoRedoSystem undoRedoSystem;
+        private UndoRedoSystem _undoRedoSystem;
 
-        private Project project;
+        private Project _project;
 
         public Project Project
         {
             get
             {
-                return project;
+                return _project;
             }
             set
             {
-                project = value;
+                _project = value;
                 BuildLevelList();
                 BuildTypeList();
             }
@@ -39,8 +39,8 @@ namespace RealmEngine
             ActiveTool = Tool.Pencil;
             SetDoubleBuffered(levelRenderer);
 
-            undoRedoSystem = new UndoRedoSystem();
-            undoRedoSystem.SystemChanged += UndoRedoSystemChanged;
+            _undoRedoSystem = new UndoRedoSystem();
+            _undoRedoSystem.SystemChanged += UndoRedoSystemChanged;
             UndoRedoSystemChanged(null, EventArgs.Empty);
 
             Project = new Project();
@@ -50,52 +50,43 @@ namespace RealmEngine
 
         private void SetupFileReaders()
         {
-            fileReaderManager = new FileReaderManager<Project>();
+            _fileReaderManager = new FileReaderManager<Project>();
             FileReader<Project> fileReader = new RealmFactoryNativeFileReader();
-            fileReaderManager.AddFileReader(fileReader);
-            fileReaderManager.SetDefaultFileReader(fileReader);
+            _fileReaderManager.AddFileReader(fileReader);
+            _fileReaderManager.SetDefaultFileReader(fileReader);
 
-            fileWriterManager = new FileWriterManager<Project>();
+            _fileWriterManager = new FileWriterManager<Project>();
             FileWriter<Project> fileWriter = new RealmFactoryNativeFileWriter();
-            fileWriterManager.AddFileWriter(fileWriter);
-            fileWriterManager.SetDefaultFileWriter(fileWriter);
+            _fileWriterManager.AddFileWriter(fileWriter);
+            _fileWriterManager.SetDefaultFileWriter(fileWriter);
         }
 
-        private bool saveNeeded = false;
+        private bool _saveNeeded = false;
         public bool SaveNeeded
         {
-            get
-            {
-                return saveNeeded;
-            }
+            get => _saveNeeded;
             set
             {
-                saveNeeded = value;
-                if (saveNeeded)
+                _saveNeeded = value;
+                if (_saveNeeded)
                 {
-                    if (!Text.EndsWith("*"))
-                    {
-                        Text += "*";
-                    }
+                    if (!Text.EndsWith("*")) Text += "*";
                 }
                 else
                 {
-                    if (Text.EndsWith("*"))
-                    {
-                        Text = Text.Substring(0, Text.Length - 1);
-                    }
+                    if (Text.EndsWith("*")) Text = Text.Substring(0, Text.Length - 1);
                 }
             }
         }
 
         public void UndoRedoSystemChanged(object sender, EventArgs e)
         {
-            undoToolStripMenuItem.Enabled = undoRedoSystem.CanUndo();
-            redoToolStripMenuItem.Enabled = undoRedoSystem.CanRedo();
+            undoToolStripMenuItem.Enabled = _undoRedoSystem.CanUndo();
+            redoToolStripMenuItem.Enabled = _undoRedoSystem.CanRedo();
             SaveNeeded = true;
         }
 
-        private OpenFileDialog imageFileDialog;
+        private OpenFileDialog _imageFileDialog;
 
         private void toolStripButton1_Click(object sender, EventArgs e)
         {
@@ -104,16 +95,16 @@ namespace RealmEngine
 
         private void AddType()
         {
-            if (imageFileDialog == null)
+            if (_imageFileDialog == null)
             {
-                imageFileDialog = new OpenFileDialog();
-                imageFileDialog.Filter = "Image Files|*.png;*.jpg;*.jpeg;*.bmp;*.tga;*.tif;*.gif|All Files|*.*";
-                imageFileDialog.Multiselect = true;
+                _imageFileDialog = new OpenFileDialog();
+                _imageFileDialog.Filter = "Image Files|*.png;*.jpg;*.jpeg;*.bmp;*.tga;*.tif;*.gif|All Files|*.*";
+                _imageFileDialog.Multiselect = true;
             }
 
-            if (imageFileDialog.ShowDialog() == DialogResult.OK)
+            if (_imageFileDialog.ShowDialog() == DialogResult.OK)
             {
-                string[] imageFiles = imageFileDialog.FileNames;
+                string[] imageFiles = _imageFileDialog.FileNames;
 
                 foreach (string imageFile in imageFiles)
                 {
@@ -169,9 +160,9 @@ namespace RealmEngine
 
                 e.Graphics.FillRectangle(new SolidBrush(Color.White), e.Bounds);
 
-                if (e.Index < project.Levels.Count)
+                if (e.Index < _project.Levels.Count)
                 {
-                    Level level = project.Levels[e.Index];
+                    Level level = _project.Levels[e.Index];
 
                     int itemHeight = levelListBox.ItemHeight;
                     SizeF size = e.Graphics.MeasureString(level.Name, levelListBox.Font);
@@ -203,16 +194,6 @@ namespace RealmEngine
             }
         }
 
-        private void typeListBox_DrawItem(object sender, DrawItemEventArgs e)
-        {
-            
-        }
-
-        private void typeListBox_SelectedIndexChanged(object sender, EventArgs e)
-        {
-
-        }
-
         private void toolStripButton5_Click(object sender, EventArgs e)
         {
             AddLevel();
@@ -224,8 +205,6 @@ namespace RealmEngine
             BuildLevelList();
             AddUndoRedoState();
         }
-
-
 
         private void levelRenderer_Paint(object sender, PaintEventArgs e)
         {
@@ -240,7 +219,7 @@ namespace RealmEngine
                 e.Graphics.FillRectangle(new SolidBrush(level.Settings.BackColor),
                     new Rectangle(0, 0, level.Settings.CellWidth * level.Settings.Columns, level.Settings.CellHeight * level.Settings.Rows));
 
-                if (this.drawGrid) { DrawGrid(e, level); }
+                if (_drawGrid) DrawGrid(e, level);
                 
                 for (int row = 0; row < level.Settings.Rows; row++)
                 {
@@ -248,9 +227,7 @@ namespace RealmEngine
                     {
                         ImageObject2D type = (ImageObject2D)level.Get(column, row);
                         if (type != null)
-                        {
                             e.Graphics.DrawImage(((ImageObject2DType)type.ParentType).Image, new Rectangle(column * cellWidth, row * cellHeight, cellWidth, cellHeight));
-                        }
                     }
                 }
             }
@@ -364,13 +341,13 @@ namespace RealmEngine
             }
         }
 
-        bool mouseStartedInRenderer = false;
+        bool _mouseStartedInRenderer = false;
 
         private void levelRenderer_MouseDown(object sender, MouseEventArgs e)
         {
             if (levelListBox.SelectedItem == null) { return; }
 
-            mouseStartedInRenderer = true;
+            _mouseStartedInRenderer = true;
 
             Level activeLevel = (Level)levelListBox.SelectedItem;
             ImageObject2DType activeType = (ImageObject2DType)objectPalette.SelectedItem;
@@ -393,10 +370,10 @@ namespace RealmEngine
                     ImageObject2D type = (ImageObject2D)activeLevel.Get(column, row);
                     if (type == null || type.ParentType != activeType)
                     {
-                        if (type != null && !project.Types.Contains(activeType)) { throw new Exception("type not in project"); }
+                        if (type != null && !_project.Types.Contains(activeType)) { throw new Exception("type not in project"); }
                         activeLevel.Put(type == null ? null : activeType.GenerateNew(), column, row);
                         levelRenderer.Refresh();
-                        somethingChanged = true;
+                        _somethingChanged = true;
                     }
                 }
             }
@@ -417,7 +394,7 @@ namespace RealmEngine
                 {
                     activeLevel.Erase(column, row);
                     levelRenderer.Refresh();
-                    somethingChanged = true;
+                    _somethingChanged = true;
                 }
             }
             if (ActiveTool == Tool.Bucket)
@@ -441,8 +418,7 @@ namespace RealmEngine
                     }
 
                     levelRenderer.Refresh();
-
-                    somethingChanged = true;
+                    _somethingChanged = true;
                 }
             }
         }
@@ -467,7 +443,7 @@ namespace RealmEngine
 
         private void levelRenderer_MouseMove(object sender, MouseEventArgs e)
         {
-            if (!mouseStartedInRenderer) { return; }
+            if (!_mouseStartedInRenderer) { return; }
 
             if (e.Button == MouseButtons.Left)
             {
@@ -494,7 +470,7 @@ namespace RealmEngine
                     {
                         activeLevel.Put(activeType == null ? null : activeType.GenerateNew(), column, row);
                         levelRenderer.Refresh();
-                        somethingChanged = true;
+                        _somethingChanged = true;
                     }
                 }
                 if (ActiveTool == Tool.Eraser)
@@ -514,7 +490,7 @@ namespace RealmEngine
                     {
                         activeLevel.Erase(column, row);
                         levelRenderer.Refresh();
-                        somethingChanged = true;
+                        _somethingChanged = true;
                     }
                 }
             }
@@ -525,31 +501,31 @@ namespace RealmEngine
             ActiveTool = Tool.Eraser;
         }
 
-        private bool somethingChanged = false;
+        private bool _somethingChanged = false;
 
         private void levelRenderer_MouseUp(object sender, MouseEventArgs e)
         {
-            mouseStartedInRenderer = false;
+            _mouseStartedInRenderer = false;
 
-            if (somethingChanged)
+            if (_somethingChanged)
             {
                 AddUndoRedoState();
             }
 
-            somethingChanged = false;
+            _somethingChanged = false;
         }
 
         private void AddUndoRedoState()
         {
-            undoRedoSystem.PushState(new ProgramState() { Project = Project.Copy(), ActiveLevelIndex = levelListBox.SelectedIndex, ActiveTypeIndex = objectPalette.SelectedIndex });
+            _undoRedoSystem.PushState(new ProgramState() { Project = Project.Copy(), ActiveLevelIndex = levelListBox.SelectedIndex, ActiveTypeIndex = objectPalette.SelectedIndex });
         }
 
         private void undoToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (undoRedoSystem.CanUndo())
+            if (_undoRedoSystem.CanUndo())
             {
                 int previouslySelectedType = objectPalette.SelectedIndex;
-                ProgramState programState = undoRedoSystem.Undo();
+                ProgramState programState = _undoRedoSystem.Undo();
                 Project = programState.Project.Copy();
                 objectPalette.GameObjects = Project.Types;
                 SelectType(previouslySelectedType);
@@ -564,10 +540,10 @@ namespace RealmEngine
 
         private void redoToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (undoRedoSystem.CanRedo())
+            if (_undoRedoSystem.CanRedo())
             {
                 int previouslySelectedType = objectPalette.SelectedIndex;
-                ProgramState programState = undoRedoSystem.Redo();
+                ProgramState programState = _undoRedoSystem.Redo();
                 Project = programState.Project.Copy();
                 levelListBox.SelectedIndex = programState.ActiveLevelIndex;
                 objectPalette.GameObjects = Project.Types;
@@ -651,23 +627,23 @@ namespace RealmEngine
             Application.Exit();
         }
 
-        private string currentProjectPath = null;
+        private string _currentProjectPath = null;
 
         private void Save()
         {
-            if (currentProjectPath == null)
+            if (_currentProjectPath == null)
             {
                 SaveAs();
             }
             else
             {
-                SaveToPath(currentProjectPath);
+                SaveToPath(_currentProjectPath);
             }
         }
 
         private void SaveToPath(string path)
         {
-            fileWriterManager.Write(path, Project);
+            _fileWriterManager.Write(path, Project);
             SaveNeeded = false;
         }
 
@@ -675,12 +651,12 @@ namespace RealmEngine
         {
             using (SaveFileDialog saveFileDialog = new SaveFileDialog())
             {
-                saveFileDialog.Filter = fileWriterManager.BuildFilter();
+                saveFileDialog.Filter = _fileWriterManager.BuildFilter();
                 if (saveFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                 {
-                    currentProjectPath = saveFileDialog.FileName;
+                    _currentProjectPath = saveFileDialog.FileName;
 
-                    SaveToPath(currentProjectPath);
+                    SaveToPath(_currentProjectPath);
                 }
             }
         }
@@ -736,7 +712,7 @@ namespace RealmEngine
             {
                 using (OpenFileDialog openFileDialog = new OpenFileDialog())
                 {
-                    openFileDialog.Filter = fileReaderManager.BuildFilter();
+                    openFileDialog.Filter = _fileReaderManager.BuildFilter();
 
                     if (openFileDialog.ShowDialog() == DialogResult.OK)
                     {
@@ -748,11 +724,11 @@ namespace RealmEngine
 
         private void OpenFile(string path)
         {
-            Project = fileReaderManager.Read(path);
-            undoRedoSystem.Clear();
+            Project = _fileReaderManager.Read(path);
+            _undoRedoSystem.Clear();
             levelListBox.SelectedIndex = 0;
             AddUndoRedoState();
-            currentProjectPath = path;
+            _currentProjectPath = path;
             SaveNeeded = false;
         }
 
@@ -792,12 +768,12 @@ namespace RealmEngine
                 }
             }
 
-            undoRedoSystem.Clear();
+            _undoRedoSystem.Clear();
             levelListBox.SelectedIndex = 0;
             AddUndoRedoState();
             SaveNeeded = false;
 
-            currentProjectPath = null;
+            _currentProjectPath = null;
         }
 
         /// <summary>
@@ -821,34 +797,27 @@ namespace RealmEngine
             return false;
         }
 
-        private bool drawGrid = true;
+        private bool _drawGrid = true;
 
         private void drawGridButton_Click(object sender, EventArgs e)
         {
-            drawGrid = drawGridButton.Checked;
+            _drawGrid = drawGridButton.Checked;
             Refresh();
         }
 
-        private void addTypeToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            AddType();
-        }
+        private void addTypeToolStripMenuItem_Click(object sender, EventArgs e) => AddType();
 
-        private void addLevelToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            AddLevel();
-        }
+        private void addLevelToolStripMenuItem_Click(object sender, EventArgs e) => AddLevel();
 
         private void ShowTypeProperties()
         {
             GameObjectType selectedType = objectPalette.SelectedItem;
-
             ShowTypeProperties(selectedType);
         }
 
         private void ShowTypeProperties(GameObjectType gameObjectType)
         {
-            if (gameObjectType == null) { return; }
+            if (gameObjectType == null) return;
 
             using (TypeSettings typeSettings = new TypeSettings())
             {
@@ -862,7 +831,7 @@ namespace RealmEngine
         {
             Level selectedLevel = (Level)levelListBox.SelectedItem;
 
-            if (selectedLevel == null) { return; }
+            if (selectedLevel == null) return;
 
             using (LevelSettings levelSettings = new LevelSettings())
             {
@@ -930,7 +899,7 @@ namespace RealmEngine
             if (selectedType == null) { return; }
             bool inUse = false;
 
-            foreach (Level level in project.Levels)
+            foreach (Level level in _project.Levels)
             {
                 if (level.UsesType(selectedType))
                 {
@@ -952,12 +921,12 @@ namespace RealmEngine
 
             if (!inUse || acceptedDelete)
             {
-                foreach (Level level in project.Levels)
+                foreach (Level level in _project.Levels)
                 {
                     level.RemoveType(selectedType);
                 }
 
-                project.Types.Remove(selectedType);
+                _project.Types.Remove(selectedType);
                 BuildTypeList();
                 AddUndoRedoState();
                 Refresh();
@@ -972,16 +941,6 @@ namespace RealmEngine
         private void typePropertiesToolStripMenuItem_Click(object sender, EventArgs e)
         {
             ShowTypeProperties();
-        }
-
-        private void typeListBox_MouseDoubleClick(object sender, MouseEventArgs e)
-        {
-            ShowTypeProperties();
-        }
-
-
-        private void typeListBox_MouseClick(object sender, MouseEventArgs e)
-        {
         }
 
         private void Form1_Shown(object sender, EventArgs e)

--- a/RealmFactory/Form1.cs
+++ b/RealmFactory/Form1.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using RealmEngine.UndoRedo;
 using Starbound.RealmFactory.UserInterface;
@@ -42,13 +37,13 @@ namespace RealmEngine
         {
             InitializeComponent();
             ActiveTool = Tool.Pencil;
-            SetDoubleBuffered(this.levelRenderer);
+            SetDoubleBuffered(levelRenderer);
 
             undoRedoSystem = new UndoRedoSystem();
             undoRedoSystem.SystemChanged += UndoRedoSystemChanged;
             UndoRedoSystemChanged(null, EventArgs.Empty);
 
-            Project = new Starbound.RealmFactory.DataModel.Project();
+            Project = new Project();
 
             SetupFileReaders();
         }
@@ -78,16 +73,16 @@ namespace RealmEngine
                 saveNeeded = value;
                 if (saveNeeded)
                 {
-                    if (!this.Text.EndsWith("*"))
+                    if (!Text.EndsWith("*"))
                     {
-                        this.Text += "*";
+                        Text += "*";
                     }
                 }
                 else
                 {
-                    if (this.Text.EndsWith("*"))
+                    if (Text.EndsWith("*"))
                     {
-                        this.Text = Text.Substring(0, Text.Length - 1);
+                        Text = Text.Substring(0, Text.Length - 1);
                     }
                 }
             }
@@ -116,7 +111,7 @@ namespace RealmEngine
                 imageFileDialog.Multiselect = true;
             }
 
-            if (imageFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            if (imageFileDialog.ShowDialog() == DialogResult.OK)
             {
                 string[] imageFiles = imageFileDialog.FileNames;
 
@@ -226,7 +221,7 @@ namespace RealmEngine
         private void AddLevel()
         {
             Project.CreateNewLevel();
-            this.BuildLevelList();
+            BuildLevelList();
             AddUndoRedoState();
         }
 
@@ -284,15 +279,15 @@ namespace RealmEngine
             }
         }
 
-        public static void SetDoubleBuffered(System.Windows.Forms.Control c)
+        public static void SetDoubleBuffered(Control c)
         {
             //Taxes: Remote Desktop Connection and painting 
             //http://blogs.msdn.com/oldnewthing/archive/2006/01/03/508694.aspx 
-            if (System.Windows.Forms.SystemInformation.TerminalServerSession)
+            if (SystemInformation.TerminalServerSession)
                 return;
 
             System.Reflection.PropertyInfo aProp =
-                  typeof(System.Windows.Forms.Control).GetProperty(
+                  typeof(Control).GetProperty(
                         "DoubleBuffered",
                         System.Reflection.BindingFlags.NonPublic |
                         System.Reflection.BindingFlags.Instance);
@@ -474,7 +469,7 @@ namespace RealmEngine
         {
             if (!mouseStartedInRenderer) { return; }
 
-            if (e.Button == System.Windows.Forms.MouseButtons.Left)
+            if (e.Button == MouseButtons.Left)
             {
                 if (levelListBox.SelectedItem == null) { return; }
 
@@ -555,7 +550,7 @@ namespace RealmEngine
             {
                 int previouslySelectedType = objectPalette.SelectedIndex;
                 ProgramState programState = undoRedoSystem.Undo();
-                this.Project = programState.Project.Copy();
+                Project = programState.Project.Copy();
                 objectPalette.GameObjects = Project.Types;
                 SelectType(previouslySelectedType);
                 Refresh();
@@ -573,7 +568,7 @@ namespace RealmEngine
             {
                 int previouslySelectedType = objectPalette.SelectedIndex;
                 ProgramState programState = undoRedoSystem.Redo();
-                this.Project = programState.Project.Copy();
+                Project = programState.Project.Copy();
                 levelListBox.SelectedIndex = programState.ActiveLevelIndex;
                 objectPalette.GameObjects = Project.Types;
                 SelectType(previouslySelectedType);
@@ -672,7 +667,7 @@ namespace RealmEngine
 
         private void SaveToPath(string path)
         {
-            fileWriterManager.Write(path, this.Project);
+            fileWriterManager.Write(path, Project);
             SaveNeeded = false;
         }
 
@@ -697,11 +692,11 @@ namespace RealmEngine
                 DialogResult result = MessageBox.Show("Do you want to save before exiting?",
                     "Realm Factory", MessageBoxButtons.YesNoCancel);
 
-                if (result == System.Windows.Forms.DialogResult.Yes)
+                if (result == DialogResult.Yes)
                 {
                     Save();
                 }
-                else if (result == System.Windows.Forms.DialogResult.Cancel)
+                else if (result == DialogResult.Cancel)
                 {
                     e.Cancel = true;
                 }
@@ -743,7 +738,7 @@ namespace RealmEngine
                 {
                     openFileDialog.Filter = fileReaderManager.BuildFilter();
 
-                    if (openFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    if (openFileDialog.ShowDialog() == DialogResult.OK)
                     {
                         OpenFile(openFileDialog.FileName);
                     }
@@ -753,9 +748,9 @@ namespace RealmEngine
 
         private void OpenFile(string path)
         {
-            this.Project = fileReaderManager.Read(path);
+            Project = fileReaderManager.Read(path);
             undoRedoSystem.Clear();
-            this.levelListBox.SelectedIndex = 0;
+            levelListBox.SelectedIndex = 0;
             AddUndoRedoState();
             currentProjectPath = path;
             SaveNeeded = false;
@@ -786,7 +781,7 @@ namespace RealmEngine
             using (Wizard wizard = new Wizard())
             {
                 wizard.Project = project;
-                if (wizard.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                if (wizard.ShowDialog() == DialogResult.OK)
                 {
                     project.CreateNewLevel();
                     Project = project;
@@ -798,7 +793,7 @@ namespace RealmEngine
             }
 
             undoRedoSystem.Clear();
-            this.levelListBox.SelectedIndex = 0;
+            levelListBox.SelectedIndex = 0;
             AddUndoRedoState();
             SaveNeeded = false;
 
@@ -814,11 +809,11 @@ namespace RealmEngine
             DialogResult result = MessageBox.Show("Do you want to save the current project before closing it?",
                 "Realm Factory", MessageBoxButtons.YesNoCancel);
 
-            if (result == System.Windows.Forms.DialogResult.Yes)
+            if (result == DialogResult.Yes)
             {
                 Save();
             }
-            else if (result == System.Windows.Forms.DialogResult.Cancel)
+            else if (result == DialogResult.Cancel)
             {
                 return true;
             }
@@ -830,8 +825,8 @@ namespace RealmEngine
 
         private void drawGridButton_Click(object sender, EventArgs e)
         {
-            this.drawGrid = drawGridButton.Checked;
-            this.Refresh();
+            drawGrid = drawGridButton.Checked;
+            Refresh();
         }
 
         private void addTypeToolStripMenuItem_Click(object sender, EventArgs e)
@@ -846,7 +841,7 @@ namespace RealmEngine
 
         private void ShowTypeProperties()
         {
-            GameObjectType selectedType = (GameObjectType)objectPalette.SelectedItem;
+            GameObjectType selectedType = objectPalette.SelectedItem;
 
             ShowTypeProperties(selectedType);
         }
@@ -919,7 +914,7 @@ namespace RealmEngine
 
             Project.Levels.Remove(selectedLevel);
 
-            this.BuildLevelList();
+            BuildLevelList();
             AddUndoRedoState();
         }
 
@@ -930,7 +925,7 @@ namespace RealmEngine
 
         private void DeleteType()
         {
-            GameObjectType selectedType = (GameObjectType)objectPalette.SelectedItem;
+            GameObjectType selectedType = objectPalette.SelectedItem;
 
             if (selectedType == null) { return; }
             bool inUse = false;
@@ -949,7 +944,7 @@ namespace RealmEngine
             if (inUse)
             {
                 DialogResult result = MessageBox.Show("The selected object type is in use.  Deleting it will remove it from all places it is used throughout the project.\n\nProceed anyway?", "Realm Factory", MessageBoxButtons.YesNoCancel);
-                if (result == System.Windows.Forms.DialogResult.Yes)
+                if (result == DialogResult.Yes)
                 {
                     acceptedDelete = true;
                 }
@@ -963,7 +958,7 @@ namespace RealmEngine
                 }
 
                 project.Types.Remove(selectedType);
-                this.BuildTypeList();
+                BuildTypeList();
                 AddUndoRedoState();
                 Refresh();
             }
@@ -1001,16 +996,16 @@ namespace RealmEngine
             using (NewOrOpenDialog gettingStartedDialog = new NewOrOpenDialog())
             {
                 DialogResult result = gettingStartedDialog.ShowDialog();
-                if (result == System.Windows.Forms.DialogResult.Yes)
+                if (result == DialogResult.Yes)
                 {
                     NewProject();
                 }
-                else if (result == System.Windows.Forms.DialogResult.Ignore) //arbitrary value, but that's what it is...
+                else if (result == DialogResult.Ignore) //arbitrary value, but that's what it is...
                 {
                     ShowTutorial();
                     NewProject();
                 }
-                else if (result == System.Windows.Forms.DialogResult.Retry) // another arbitrary value... for open project.
+                else if (result == DialogResult.Retry) // another arbitrary value... for open project.
                 {
                     Project = new Project();
                     PerformOpenFile(false);
@@ -1028,7 +1023,7 @@ namespace RealmEngine
             {
                 using (EulaDialog eulaDialog = new EulaDialog())
                 {
-                    if (eulaDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    if (eulaDialog.ShowDialog() == DialogResult.OK)
                     {
                         Starbound.RealmFactory.Properties.Settings.Default.AcceptedEulaVersion = Constants.VersionString;
                         Starbound.RealmFactory.Properties.Settings.Default.Save();
@@ -1081,7 +1076,7 @@ namespace RealmEngine
                 AddLevel();
             }
 
-            this.Refresh();
+            Refresh();
         }
 
         private void objectPalette_NewObjectClicked(object sender, EventArgs e)

--- a/RealmFactory/Form1.cs
+++ b/RealmFactory/Form1.cs
@@ -7,6 +7,7 @@ using Starbound.Common.IO;
 using Starbound.RealmFactory.IO;
 using Starbound.RealmFactory;
 using Starbound.RealmFactory.DataModel;
+using System.Collections.Generic;
 
 namespace RealmEngine
 {
@@ -454,22 +455,31 @@ namespace RealmEngine
             return false;
         }
 
+        private class Location
+        {
+            public int Row { get; }
+            public int Column { get; }
+            public Location(int row, int column) { Row = row; Column = column; }
+        }
+
         private void Fill(Level activeLevel, int row, int column, GameObject original, GameObject changeToType)
         {
-            if (row < 0) { return; }
-            if (row >= activeLevel.Settings.Rows) { return; }
+            Queue<Location> fillQueue = new Queue<Location>();
+            fillQueue.Enqueue(new Location(row, column));
 
-            if (column < 0) { return; }
-            if (column >= activeLevel.Settings.Columns) { return; }
+            while(fillQueue.Count > 0)
+            {
+                Location location = fillQueue.Dequeue();
+                if (!IsInBounds(activeLevel, location.Row, location.Column)) continue;
+                if (activeLevel.Get(location.Column, location.Row) != original) continue;
 
-            if (activeLevel.Get(column, row) != original) { return; }
+                activeLevel.Put(changeToType, location.Column, location.Row);
 
-            activeLevel.Put(changeToType, column, row);
-
-            Fill(activeLevel, row - 1, column, original, changeToType);
-            Fill(activeLevel, row + 1, column, original, changeToType);
-            Fill(activeLevel, row, column - 1, original, changeToType);
-            Fill(activeLevel, row, column + 1, original, changeToType);
+                fillQueue.Enqueue(new Location(location.Row - 1, location.Column));
+                fillQueue.Enqueue(new Location(location.Row + 1, location.Column));
+                fillQueue.Enqueue(new Location(location.Row, location.Column - 1));
+                fillQueue.Enqueue(new Location(location.Row, location.Column + 1));
+            }
         }
 
         private void levelRenderer_MouseMove(object sender, MouseEventArgs e)

--- a/RealmFactory/Form1.cs
+++ b/RealmFactory/Form1.cs
@@ -354,73 +354,104 @@ namespace RealmEngine
 
             if (ActiveTool == Tool.Pencil)
             {
-                if (activeType == null) MessageBox.Show("Select an object in the Object Palette to use this tool.", "No object selected", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                else
+                bool somethingChanged = UsePencilTool(new Point(e.X, e.Y), activeType, activeLevel);
+                if (somethingChanged)
                 {
-                    Point position = new Point(e.X, e.Y);
-                    int row = position.Y / activeLevel.Settings.CellHeight;
-                    int column = position.X / activeLevel.Settings.CellWidth;
-
-                    if (row < 0) { return; }
-                    if (row >= activeLevel.Settings.Rows) { return; }
-
-                    if (column < 0) { return; }
-                    if (column >= activeLevel.Settings.Columns) { return; }
-
-                    ImageObject2D type = (ImageObject2D)activeLevel.Get(column, row);
-                    if (type == null || type.ParentType != activeType)
-                    {
-                        if (type != null && !_project.Types.Contains(activeType)) { throw new Exception("type not in project"); }
-                        activeLevel.Put(type == null ? null : activeType.GenerateNew(), column, row);
-                        levelRenderer.Refresh();
-                        _somethingChanged = true;
-                    }
+                    levelRenderer.Refresh();
+                    _somethingChanged = true;
                 }
             }
             if (ActiveTool == Tool.Eraser)
             {
-                Point position = new Point(e.X, e.Y);
-                int row = position.Y / activeLevel.Settings.CellHeight;
-                int column = position.X / activeLevel.Settings.CellWidth;
-
-                if (row < 0) { return; }
-                if (row >= activeLevel.Settings.Rows) { return; }
-
-                if (column < 0) { return; }
-                if (column >= activeLevel.Settings.Columns) { return; }
-
-                ImageObject2D type = (ImageObject2D)activeLevel.Get(column, row);
-                if (type != null)
+                bool somethingChanged = UseEraserTool(new Point(e.X, e.Y), activeType, activeLevel);
+                if (somethingChanged)
                 {
-                    activeLevel.Erase(column, row);
                     levelRenderer.Refresh();
                     _somethingChanged = true;
                 }
             }
             if (ActiveTool == Tool.Bucket)
             {
-                if (activeType == null) MessageBox.Show("Select an object in the Object Palette to use this tool.", "No object selected", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                else
+                bool somethingChanged = UseFillTool(new Point(e.X, e.Y), activeType, activeLevel);
+                if (somethingChanged)
                 {
-                    Point position = new Point(e.X, e.Y);
-                    int row = position.Y / activeLevel.Settings.CellHeight;
-                    int column = position.X / activeLevel.Settings.CellWidth;
-
-                    if (row < 0) { return; }
-                    if (row >= activeLevel.Settings.Rows) { return; }
-
-                    if (column < 0) { return; }
-                    if (column >= activeLevel.Settings.Columns) { return; }
-
-                    if (activeLevel.Get(column, row) == null || activeLevel.Get(column, row).ParentType != activeType)
-                    {
-                        Fill(activeLevel, row, column, activeLevel.Get(column, row), activeType.GenerateNew());
-                    }
-
                     levelRenderer.Refresh();
                     _somethingChanged = true;
                 }
             }
+        }
+
+        private bool UsePencilTool(Point position, ImageObject2DType activeType, Level activeLevel)
+        {
+            if (activeType == null)
+            {
+                MessageBox.Show("Select an object in the Object Palette to use this tool.", "No object selected", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
+
+            int row = position.Y / activeLevel.Settings.CellHeight;
+            int column = position.X / activeLevel.Settings.CellWidth;
+
+            if (!IsInBounds(activeLevel, row, column)) return false;
+
+            ImageObject2D type = (ImageObject2D)activeLevel.Get(column, row);
+            if (type == null || type.ParentType != activeType)
+            {
+                if (type != null && !_project.Types.Contains(activeType)) { throw new Exception("type not in project"); }
+                activeLevel.Put(type == null ? null : activeType.GenerateNew(), column, row);
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool UseEraserTool(Point position, ImageObject2DType activeType, Level activeLevel)
+        {
+            int row = position.Y / activeLevel.Settings.CellHeight;
+            int column = position.X / activeLevel.Settings.CellWidth;
+
+            if (!IsInBounds(activeLevel, row, column)) return false;
+
+            ImageObject2D type = (ImageObject2D)activeLevel.Get(column, row);
+            if (type != null)
+            {
+                activeLevel.Erase(column, row);
+                return true;
+            }
+            return false;
+        }
+
+        private bool IsInBounds(Level level, int row, int column)
+        {
+            if (row < 0) return false;
+            if (row >= level.Settings.Rows) return false;
+
+            if (column < 0) return false;
+            if (column >= level.Settings.Columns) return false;
+
+            return true;
+        }
+
+        private bool UseFillTool(Point position, ImageObject2DType activeType, Level activeLevel)
+        {
+            if (activeType == null)
+            {
+                MessageBox.Show("Select an object in the Object Palette to use this tool.", "No object selected", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
+
+            int row = position.Y / activeLevel.Settings.CellHeight;
+            int column = position.X / activeLevel.Settings.CellWidth;
+
+            if (!IsInBounds(activeLevel, row, column)) return false;
+
+            if (activeLevel.Get(column, row) == null || activeLevel.Get(column, row).ParentType != activeType)
+            {
+                Fill(activeLevel, row, column, activeLevel.Get(column, row), activeType.GenerateNew());
+                return true;
+            }
+
+            return false;
         }
 
         private void Fill(Level activeLevel, int row, int column, GameObject original, GameObject changeToType)

--- a/RealmFactory/Form1.cs
+++ b/RealmFactory/Form1.cs
@@ -471,7 +471,9 @@ namespace RealmEngine
             {
                 Location location = fillQueue.Dequeue();
                 if (!IsInBounds(activeLevel, location.Row, location.Column)) continue;
-                if (activeLevel.Get(location.Column, location.Row) != original) continue;
+                GameObject currentObject = activeLevel.Get(location.Column, location.Row);
+                if ((original == null) != (currentObject == null)) continue;
+                if (currentObject != null && currentObject.ParentType != original.ParentType) continue;
 
                 activeLevel.Put(changeToType, location.Column, location.Row);
 


### PR DESCRIPTION
Fixed two bugs related to the paint can tool:

1. Fixed a crash on large levels.
2. Fixed a problem where if you were using the paint can on non-empty cells, it would just change the one you clicked on and not its neighbors.